### PR TITLE
Update the recommended way of retrieving your current language.

### DIFF
--- a/translations.md
+++ b/translations.md
@@ -3,7 +3,7 @@
 
 ## Your language is currently not supported?
 1. Start up [Stadia](https://stadia.com/).
-2. Get your current language code via `document.querySelector("html").getAttribute("lang");` in the console (Ctrl+Shift+I). This will return the language code used by Stadia.
+2. Get your current language code via `navigator.language` in the console (Ctrl+Shift+I). This will return the language code used by Stadia.
 3. Submit a copy of the current template below with the values on the right side translated, together with your language code via a [issues entry](https://github.com/ChristopherKlay/StadiaEnhanced/issues), so we don't get duplicates and/or more refined translations due to access of multiple people.
 
 Please note that for the sake of simplicity, en-gb/en-us will default to "en" for example.


### PR DESCRIPTION
`navigator.language` is a much better way of retrieving the current language. Retrieving the language from the current webpage html is dependent on that webpage (in this case GitHub) actually supporting your language.