### PR TITLE
Add ability to set the current language as default

### DIFF
--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -641,10 +641,21 @@ enhanced_langDropContent.style.boxShadow = "0 0.25rem 2.5rem rgba(0,0,0,0.30), 0
 enhanced_langDropContent.style.zIndex = "20";
 enhanced_langDropContent.style.display = "none";
 
+
+var enhanced_currentLanguage = new URL(window.location.href).searchParams.get("hl");
+
+// Support for Default Language is here
+if (!enhanced_currentLanguage && localStorage.getItem("enhanced_Language")) {
+    enhanced_urlBase = new URL(window.location.href);
+    enhanced_urlBase.searchParams.set('hl', localStorage.getItem("enhanced_Language"))
+    history.replaceState(null, null, enhanced_urlBase.pathname + "?" + enhanced_urlBase.searchParams);
+    openStadia(enhanced_urlBase.pathname.substring(1));
+}
+
 // Language Select - Default
 var enhanced_langDefault = document.createElement("div");
 enhanced_langDefault.className = "pBvcyf QAAyWd";
-enhanced_langDefault.innerHTML = '<span class="mJVLwb">' + enhanced_lang.default+'</span>';
+enhanced_langDefault.innerHTML = '<span class="mJVLwb">' + enhanced_lang.default +  (!enhanced_currentLanguage ? ' ✔️' : '') + '</span>';
 enhanced_langDefault.style.cursor = "pointer";
 enhanced_langDefault.style.userSelect = "none";
 enhanced_langDefault.style.padding = "0 2rem";
@@ -655,6 +666,7 @@ enhanced_langDefault.addEventListener("click", function() {
     enhanced_urlBase = new URL(window.location.href);
     enhanced_urlBase.searchParams.delete('hl')
     history.replaceState(null, null, "?" + enhanced_urlBase.searchParams);
+    localStorage.removeItem("enhanced_Language");
     openStadia("home");
 });
 enhanced_langDropContent.append(enhanced_langDefault);
@@ -662,7 +674,7 @@ enhanced_langDropContent.append(enhanced_langDefault);
 // Language Select - English
 var enhanced_langEnglish = document.createElement("div");
 enhanced_langEnglish.className = "pBvcyf QAAyWd";
-enhanced_langEnglish.innerHTML = '<span class="mJVLwb">English</span>';
+enhanced_langEnglish.innerHTML = '<span class="mJVLwb">English' + (enhanced_currentLanguage === 'en' ? ' ✔️' : '') + '</span>';
 enhanced_langEnglish.style.cursor = "pointer";
 enhanced_langEnglish.style.userSelect = "none";
 enhanced_langEnglish.style.padding = "0 2rem";
@@ -679,7 +691,7 @@ enhanced_langDropContent.append(enhanced_langEnglish);
 // Language Select - Spanish
 var enhanced_langSpanish = document.createElement("div");
 enhanced_langSpanish.className = "pBvcyf QAAyWd";
-enhanced_langSpanish.innerHTML = '<span class="mJVLwb">Spanish</span>';
+enhanced_langSpanish.innerHTML = '<span class="mJVLwb">Spanish' + (enhanced_currentLanguage === 'es' ? ' ✔️' : '') + '</span>';
 enhanced_langSpanish.style.cursor = "pointer";
 enhanced_langSpanish.style.userSelect = "none";
 enhanced_langSpanish.style.padding = "0 2rem";
@@ -696,7 +708,7 @@ enhanced_langDropContent.append(enhanced_langSpanish);
 // Language Select - French
 var enhanced_langFrench = document.createElement("div");
 enhanced_langFrench.className = "pBvcyf QAAyWd";
-enhanced_langFrench.innerHTML = '<span class="mJVLwb">French</span>';
+enhanced_langFrench.innerHTML = '<span class="mJVLwb">French' + (enhanced_currentLanguage === 'fr' ? ' ✔️' : '') + '</span>';
 enhanced_langFrench.style.cursor = "pointer";
 enhanced_langFrench.style.userSelect = "none";
 enhanced_langFrench.style.padding = "0 2rem";
@@ -709,6 +721,25 @@ enhanced_langFrench.addEventListener("click", function() {
     openStadia("home");
 });
 enhanced_langDropContent.append(enhanced_langFrench);
+
+// Language Select - Save
+if (localStorage.getItem("enhanced_Language") !== enhanced_currentLanguage) {
+    var enhanced_langSave = document.createElement("div");
+    enhanced_langSave.className = "pBvcyf QAAyWd";
+    enhanced_langSave.innerHTML = '<span class="mJVLwb">Always load with "' + enhanced_currentLanguage + '"</span>';
+    enhanced_langSave.style.cursor = "pointer";
+    enhanced_langSave.style.userSelect = "none";
+    enhanced_langSave.style.padding = "0 2rem";
+    enhanced_langSave.style.textAlign = "center";
+    enhanced_langSave.tabIndex = "0";
+    enhanced_langSave.addEventListener("click", function() {
+        enhanced_urlBase = new URL(window.location.href);
+        localStorage.setItem("enhanced_Language", enhanced_urlBase.searchParams.get('hl'));
+        enhanced_langDropContent.removeChild(enhanced_langSave);
+    });
+    enhanced_langDropContent.append(enhanced_langSave);
+}
+
 secureInsert(enhanced_langContainer, ".ZECEje", 1)
 
 enhanced_langDropdown.addEventListener("keyup", function(e) {
@@ -3085,7 +3116,7 @@ function enhanced_injectStyle(content, id) {
 function openStadia(url) {
     // Keep hl parameter
     enhanced_urlBase = document.querySelector("head > base").getAttribute("href")
-    enhanced_urlHL = new URL(window.location.href).searchParams.get('hl')
+    enhanced_urlHL = new URL(window.location.href).searchParams.get('hl') || localStorage.getItem("enhanced_Language");
     if (enhanced_urlHL) {
         enhanced_urlBase = new URL(enhanced_urlBase + url);
         enhanced_urlBase.searchParams.set('hl', enhanced_urlHL)

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -649,7 +649,6 @@ if (!enhanced_currentLanguage && localStorage.getItem("enhanced_Language")) {
     enhanced_urlBase = new URL(window.location.href);
     enhanced_urlBase.searchParams.set('hl', localStorage.getItem("enhanced_Language"))
     history.replaceState(null, null, enhanced_urlBase.pathname + "?" + enhanced_urlBase.searchParams);
-    openStadia(enhanced_urlBase.pathname.substring(1));
 }
 
 // Language Select - Default
@@ -723,10 +722,10 @@ enhanced_langFrench.addEventListener("click", function() {
 enhanced_langDropContent.append(enhanced_langFrench);
 
 // Language Select - Save
-if (localStorage.getItem("enhanced_Language") !== enhanced_currentLanguage) {
+if (!!localStorage.getItem("enhanced_Language") && localStorage.getItem("enhanced_Language") !== enhanced_currentLanguage) {
     var enhanced_langSave = document.createElement("div");
     enhanced_langSave.className = "pBvcyf QAAyWd";
-    enhanced_langSave.innerHTML = '<span class="mJVLwb">Always load with "' + enhanced_currentLanguage + '"</span>';
+    enhanced_langSave.innerHTML = '<span class="mJVLwb">' + enhanced_lang.default + ' "' + enhanced_currentLanguage + '"</span>';
     enhanced_langSave.style.cursor = "pointer";
     enhanced_langSave.style.userSelect = "none";
     enhanced_langSave.style.padding = "0 2rem";
@@ -3358,7 +3357,8 @@ function enhancedTranslate(lang, log = false) {
         familyelementsdesc: 'Hides the "Share this game with family" options.',
         donations: 'Donations',
         reportbug: 'Report a bug',
-        resetsettings: 'Reset Settings'
+        resetsettings: 'Reset Settings',
+        alwaysLoadWith: 'Always load with',
     }
 
     // Load translation
@@ -3469,7 +3469,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: 'Versteckt die "Dieses Spiel für die Familie freigeben" Elemente.',
                 donations: 'Spenden',
                 reportbug: 'Melde einen Fehler',
-                resetsettings: 'Einstellungen zurücksetzen'
+                resetsettings: 'Einstellungen zurücksetzen',
+                alwaysLoadWith: undefined
             }
             break
         case 'hu': // https://github.com/ChristopherKlay/StadiaEnhanced/discussions/97
@@ -3575,7 +3576,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: 'Elrejti "A játék megosztása a családdal" lehetőséget a játékoknál, ha már létrehoztál családi csoportot.',
                 donations: undefined,
                 reportbug: undefined,
-                resetsettings: 'Beállítások alaphelyzetbe állítása'
+                resetsettings: 'Beállítások alaphelyzetbe állítása',
+                alwaysLoadWith: undefined
             }
             break
         case 'nl': // https://github.com/ChristopherKlay/StadiaEnhanced/discussions/9
@@ -3681,7 +3683,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: 'Verbergt de "Delen met gezin"-opties.',
                 donations: undefined,
                 reportbug: undefined,
-                resetsettings: 'Reset Instellingen'
+                resetsettings: 'Reset Instellingen',
+                alwaysLoadWith: undefined
             }
             break
         case 'es': // https://github.com/ChristopherKlay/StadiaEnhanced/discussions/67
@@ -3787,7 +3790,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: undefined,
                 donations: undefined,
                 reportbug: undefined,
-                resetsettings: 'Restablecer los ajustes'
+                resetsettings: 'Restablecer los ajustes',
+                alwaysLoadWith: undefined
             }
             break
         case 'it': // https://github.com/ChristopherKlay/StadiaEnhanced/discussions/7
@@ -3893,7 +3897,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: 'Nasconde l\'opzione "Condividi questo gioco con la famiglia".',
                 donations: 'Donazioni',
                 reportbug: 'Segnala un bug',
-                resetsettings: 'Ripristina Impostazioni'
+                resetsettings: 'Ripristina Impostazioni',
+                alwaysLoadWith: undefined
             }
             break
         case 'da': // https://github.com/ChristopherKlay/StadiaEnhanced/discussions/81
@@ -3999,7 +4004,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: undefined,
                 donations: undefined,
                 reportbug: undefined,
-                resetsettings: 'Nulstil indstillingerne'
+                resetsettings: 'Nulstil indstillingerne',
+                alwaysLoadWith: undefined
             }
             break
         case 'ca': // https://github.com/ChristopherKlay/StadiaEnhanced/discussions/60
@@ -4105,7 +4111,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: 'Amaga les opcions "Comparteix aquest joc amb la família."',
                 donations: undefined,
                 reportbug: undefined,
-                resetsettings: 'Restableix la configuració'
+                resetsettings: 'Restableix la configuració',
+                alwaysLoadWith: undefined
             }
             break
         case 'pt': // https://github.com/ChristopherKlay/StadiaEnhanced/discussions/91
@@ -4211,7 +4218,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: 'Esconder a opção "Partilhar este jogo com a família."',
                 donations: undefined,
                 reportbug: undefined,
-                resetsettings: 'Reiniciar Configurações'
+                resetsettings: 'Reiniciar Configurações',
+                alwaysLoadWith: undefined
             }
             break
         case 'sv': // https://github.com/ChristopherKlay/StadiaEnhanced/discussions/11
@@ -4317,7 +4325,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: undefined,
                 donations: undefined,
                 reportbug: undefined,
-                resetsettings: 'Återställ Inställningar'
+                resetsettings: 'Återställ Inställningar',
+                alwaysLoadWith: undefined
             }
             break
         case 'fr': //https://github.com/ChristopherKlay/StadiaEnhanced/discussions/8
@@ -4423,7 +4432,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: 'Masque l\'option "Partager ce jeu avec la famille".',
                 donations: undefined,
                 reportbug: undefined,
-                resetsettings: 'Réinitialiser les Paramètres'
+                resetsettings: 'Réinitialiser les Paramètres',
+                alwaysLoadWith: "Toujours charger avec"
             }
             break
         case 'ru':
@@ -4529,7 +4539,8 @@ function enhancedTranslate(lang, log = false) {
                 familyelementsdesc: 'Прячеть опцию "поделится играми " из настроек.',
                 donations: undefined,
                 reportbug: undefined,
-                resetsettings: 'Сбросить настройки'
+                resetsettings: 'Сбросить настройки',
+                alwaysLoadWith: undefined
             }
             break
     }

--- a/translations.md
+++ b/translations.md
@@ -138,6 +138,7 @@ var translation = {
     familyelementsdesc: 'Hides the "Share this game with family" options.',
     donations: 'Donations',
     reportbug: 'Report a bug',
-    resetsettings: 'Reset Settings'
+    resetsettings: 'Reset Settings',
+    alwaysLoadWith: 'Always load with'
 }
 ```


### PR DESCRIPTION
:wave: 

I tried the extension today and was pleased to see there was a Language picker! One of the thing that I found very annoying with Stadia is that it loads the page with your account language without allowing us to set a default.

So here it is! If you change the language, the "Always load with" option will be shown. If you select it, if no `hl` is set, it will set it to your saved language.

This effectively means that you can now set a default language :smile: 

It also works if you manually change the `hl` parameter in the URL.

While not really necessary for this feature, I also added some visual feedback when the current language matches the row.

Let me know if there is anything wrong :smile: 

I also didn't take care of translation for the new button, should I implement it right now?