### PR TITLE
StreamMonitor mode-cycling

### DIFF
--- a/extension/data.js
+++ b/extension/data.js
@@ -9,7 +9,7 @@ class StreamDataService {
      * @property {string} date - Date of the streaming recording
      * @property {string} time - Time of the streaming recording
      * @property {string} sessiontime - Duration of the current session in format "HH:MM:SS"
-     * @property {string} codec - The video compression standard used. Can have the following values:
+     * @property {("Hardware H264"|"Hardware VP9"|"Software VP9")} codec - The video compression standard used. Can have the following values:
      *      - "Hardware H264":
      *          Older, most popular codec. Only supports resolutions up to 1080p.
      *      - "Hardware VP9":
@@ -18,11 +18,11 @@ class StreamDataService {
      *      - "Software VP9":
      *          See "Hardware VP9". When hardware doesn't support VP, you can force it anyway.
      * @property {string} resolution - Current browser resolution in width by height (e.g. "2560x1440")
-     * @property {string} fps - Frames per second of the video stream (NOT the game itself)
+     * @property {number} fps - Frames per second of the video stream (NOT the game itself)
      * @property {string} compression
-     * @property {string} decode - Decoding time in ms
+     * @property {number} decode - Decoding time in ms
      * @property {string} framedrop - Number and percentage of frames dropped
-     * @property {string} framedropPerc - Percentage of frames dropped (e.g. "0.000")
+     * @property {number} framedropPerc - Percentage of frames dropped (e.g. "0.000")
      * @property {string} sessionTraffic - e.g. "39.13 MB"
      * @property {string} currentTraffic - e.g. "424.21 Kb",
      * @property {string} averageTraffic - e.g. "1.94 GB/h",
@@ -41,6 +41,14 @@ class StreamDataService {
         if (json == null) {
             return null;
         }
-        return JSON.parse(json)
+        const data = JSON.parse(json)
+
+        // conversions (should be done when saved in the future)
+        data.fps = parseFloat(data.fps) // string to float
+        data.decode = parseFloat(data.decode) // string to float
+        data.framedropPerc = parseFloat(data.framedropPerc) // string to float
+        data.latency = parseInt(data.latency) // string to int
+
+        return data
     }
 }

--- a/extension/data.js
+++ b/extension/data.js
@@ -1,0 +1,46 @@
+/**
+ * Handles the retrieval of steaming data.
+ */
+class StreamDataService {
+    _KEY = "enhanced_streamData"
+
+    /**
+     * @typedef {Object} Data - streaming info
+     * @property {string} date - Date of the streaming recording
+     * @property {string} time - Time of the streaming recording
+     * @property {string} sessiontime - Duration of the current session in format "HH:MM:SS"
+     * @property {string} codec - The video compression standard used. Can have the following values:
+     *      - "Hardware H264":
+     *          Older, most popular codec. Only supports resolutions up to 1080p.
+     *      - "Hardware VP9":
+     *          Codec from Google that was developed from technology acquired when Google purchased On2 Technologies in
+     *          February 2010. Supports resolutions up to 4K. In Stadia, uses a higher bitrate than H264.
+     *      - "Software VP9":
+     *          See "Hardware VP9".
+     * @property {string} resolution - Current browser resolution in width by height (e.g. "2560x1440")
+     * @property {string} fps - Frames per second of the video stream (NOT the game itself)
+     * @property {string} compression
+     * @property {string} decode - Decoding time in ms
+     * @property {string} framedrop - Number and percentage of frames dropped
+     * @property {string} framedropPerc - Percentage of frames dropped (e.g. "0.000")
+     * @property {string} sessionTraffic - e.g. "39.13 MB"
+     * @property {string} currentTraffic - e.g. "424.21 Kb",
+     * @property {string} averageTraffic - e.g. "1.94 GB/h",
+     * @property {string} packetloss - Number and percentage of packets lost, e.g. "0 (0.000%)",
+     * @property {number} latency - Latency in ms
+     * @property {string} jitter - Jitter buffer (e.g. "28.70 ms")
+     */
+
+    /**
+     * Returns streaming data obtained from analyzing RTCPeerConnection objects.
+     *
+     * @returns {Data|null} data
+     */
+    getData() {
+        const json = localStorage.getItem(this._KEY);
+        if (json == null) {
+            return null;
+        }
+        return JSON.parse(json)
+    }
+}

--- a/extension/data.js
+++ b/extension/data.js
@@ -16,7 +16,7 @@ class StreamDataService {
      *          Codec from Google that was developed from technology acquired when Google purchased On2 Technologies in
      *          February 2010. Supports resolutions up to 4K. In Stadia, uses a higher bitrate than H264.
      *      - "Software VP9":
-     *          See "Hardware VP9".
+     *          See "Hardware VP9". When hardware doesn't support VP, you can force it anyway.
      * @property {string} resolution - Current browser resolution in width by height (e.g. "2560x1440")
      * @property {string} fps - Frames per second of the video stream (NOT the game itself)
      * @property {string} compression

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -485,84 +485,6 @@ const monitor = new StreamMonitor(enhanced_lang, enhanced_settings.monitorPositi
 const enhanced_streamMonitor = monitor.getElement();
 
 enhanced_streamMonitor.addEventListener('dblclick', function () {
-    monitor.toggleMode()
-
-    // Save monitor mode
-    enhanced_settings.monitorMode = (enhanced_settings.monitorMode + 1) % 2
-    localStorage.setItem('enhanced_' + enhanced_settings.user, JSON.stringify(enhanced_settings))
-})
-
-document.body.appendChild(enhanced_streamMonitor)
-enhanced_dragElement(enhanced_streamMonitor)
-
-// Update Stream Elements
-setInterval(function () {
-    if (!isLocation('ingame')) {
-        monitor.reset()
-        return
-    }
-
-    // Get local stream data
-    var enhanced_streamData = localStorage.getItem('enhanced_streamData');
-    if (enhanced_streamData == null) {
-        return;
-    }
-    const data = JSON.parse(enhanced_streamData)
-
-    if (enhanced_newMonitorPos != enhanced_settings.monitorPosition) {
-        var enhanced_newMonitorPos = enhanced_settings.monitorPosition
-        localStorage.setItem('enhanced_' + enhanced_settings.user, JSON.stringify(enhanced_settings))
-    }
-
-    let fullMode = enhanced_settings.monitorMode === 0;
-    monitor.refreshContent(fullMode)
-}, 1000)
-
-// Streaming Monitor (Menu Icon)
-var enhanced_Monitor = document.createElement('div')
-enhanced_Monitor.className = 'R2s0be'
-enhanced_Monitor.id = 'enhanced_Monitor'
-enhanced_Monitor.innerHTML = `
-    <div role="button" class="CTvDXd QAAyWd Pjpac zcMYd CPNFX">
-
-        <!-- Icon -->
-        <span class="X5peoe" jsname="pYFhU">
-            <i class="material-icons-extended" style="font-size: 2rem !important" aria-hidden="true">analytics</i>
-        </span>
-        
-        <!-- Text -->
-        <span class="caSJV" jsname="V67aGc">${enhanced_lang.streammon}</span>
-        
-        <span id="monitor-type" style="color: rgba(255,255,255,.4);font-size: 0.7rem; display: none;">Standard</span>        
-    </div>
-`
-enhanced_Monitor.style.cursor = 'pointer'
-enhanced_Monitor.style.userSelect = 'none'
-enhanced_Monitor.tabIndex = '0'
-
-// click on menu item "stream monitor"
-enhanced_Monitor.addEventListener('click', () => {
-    const button = enhanced_Monitor
-    const $icon = button.querySelector("span.X5peoe")
-    const $typeDescription = button.querySelector("#monitor-type")
-
-    monitor.toggleMode(enhanced_settings.monitorPosition)
-
-    // update color
-    if (monitor.currentMode === "hidden") {
-        $icon.style.color = ""
-        $typeDescription.style.display = "none"
-    } else {
-        $icon.style.color = "#00e0ba"
-
-        $typeDescription.textContent = monitor.currentMode
-        $typeDescription.style.display = "block"
-    }
-});
-
-// double-click on menu item "stream monitor"
-enhanced_Monitor.addEventListener('dblclick', function () {
-
     // Generate new Window
     var enhanced_popMonitor = window.open('', '_blank', 'width=280,height=500,toolbar=0')
     enhanced_popMonitor.document.title = 'Stream Monitor'
@@ -583,6 +505,72 @@ enhanced_Monitor.addEventListener('dblclick', function () {
         }
     }, 1000)
 })
+
+document.body.appendChild(enhanced_streamMonitor)
+enhanced_dragElement(enhanced_streamMonitor)
+
+// Update Stream Elements
+setInterval(function () {
+    if (!isLocation('ingame')) {
+        monitor.reset()
+        return
+    }
+
+    // Get local stream data
+    var enhanced_streamData = localStorage.getItem('enhanced_streamData');
+    if (enhanced_streamData == null) {
+        return;
+    }
+
+    const data = JSON.parse(enhanced_streamData)
+
+    if (enhanced_newMonitorPos != enhanced_settings.monitorPosition) {
+        var enhanced_newMonitorPos = enhanced_settings.monitorPosition
+        localStorage.setItem('enhanced_' + enhanced_settings.user, JSON.stringify(enhanced_settings))
+    }
+
+    let fullMode = enhanced_settings.monitorMode === 0;
+    monitor.updateValues(data)
+}, 1000)
+
+// Streaming Monitor (Menu Icon)
+var enhanced_Monitor = document.createElement('div')
+enhanced_Monitor.className = 'R2s0be'
+enhanced_Monitor.id = 'enhanced_Monitor'
+enhanced_Monitor.innerHTML = `
+    <div role="button" class="CTvDXd QAAyWd Pjpac zcMYd CPNFX">
+
+        <!-- Icon -->
+        <span class="X5peoe" jsname="pYFhU">
+            <i class="material-icons-extended" style="font-size: 2rem !important" aria-hidden="true">analytics</i>
+        </span>
+        
+        <!-- Text -->
+        <span class="caSJV" jsname="V67aGc">${enhanced_lang.streammon}</span>
+        
+        <span id="monitor-type" style="color: rgba(255,255,255,.4);font-size: 0.7rem; height: 0.5rem;"></span>        
+    </div>
+`
+enhanced_Monitor.style.cursor = 'pointer'
+enhanced_Monitor.style.userSelect = 'none'
+enhanced_Monitor.tabIndex = '0'
+
+// click on menu item "stream monitor"
+enhanced_Monitor.addEventListener('click', () => {
+    const button = enhanced_Monitor
+    const $icon = button.querySelector("span.X5peoe")
+    const $typeDescription = button.querySelector("#monitor-type")
+
+    monitor.toggleMode(enhanced_settings.monitorPosition)
+
+    if (monitor.isVisible()) {
+        $icon.style.color = "#00e0ba"
+        $typeDescription.textContent = monitor.currentMode
+    } else {
+        $icon.style.color = ""
+        $typeDescription.textContent = ""
+    }
+});
 
 // Filter UI
 var enhanced_filterUI = {

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -564,7 +564,7 @@ enhanced_Monitor.addEventListener('click', () => {
     monitor.toggleMode(enhanced_settings.monitorPosition)
     enhanced_saveMonitorMode(monitor.currentMode)
 
-    if (monitor.isVisible()) {
+    if (monitor.isVisible() && monitor.currentMode !== "Hidden") {
         $icon.style.color = "#00e0ba"
         $typeDescription.textContent = monitor.currentMode
     } else {
@@ -576,7 +576,7 @@ enhanced_Monitor.addEventListener('click', () => {
 // Update Stream Elements
 setInterval(function () {
     if (!isLocation('ingame')) {
-        monitor.reset()
+        monitor.reset(enhanced_settings.monitorAutostart === 1)
 
         // disable monitor-icon
         enhanced_Monitor.disabled = true
@@ -604,9 +604,13 @@ setInterval(function () {
         localStorage.setItem('enhanced_' + enhanced_settings.user, JSON.stringify(enhanced_settings))
     }
 
-    let fullMode = enhanced_settings.monitorMode === 0;
-    monitor.updateValues(data)
-    monitor.showMode(monitor.currentMode)
+    if (monitor.isVisible()) {
+        monitor.updateValues(data)
+
+        console.log("SHOW MODE: " + monitor.currentMode)
+        monitor.showMode(monitor.currentMode)
+    }
+
 }, 1000)
 
 // Filter UI

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -509,36 +509,19 @@ enhanced_streamMonitor.addEventListener('dblclick', function () {
 document.body.appendChild(enhanced_streamMonitor)
 enhanced_dragElement(enhanced_streamMonitor)
 
-// Update Stream Elements
-setInterval(function () {
-    if (!isLocation('ingame')) {
-        monitor.reset()
-        return
-    }
-
-    // Get local stream data
-    var enhanced_streamData = localStorage.getItem('enhanced_streamData');
-    if (enhanced_streamData == null) {
-        return;
-    }
-
-    const data = JSON.parse(enhanced_streamData)
-
-    if (enhanced_newMonitorPos != enhanced_settings.monitorPosition) {
-        var enhanced_newMonitorPos = enhanced_settings.monitorPosition
-        localStorage.setItem('enhanced_' + enhanced_settings.user, JSON.stringify(enhanced_settings))
-    }
-
-    let fullMode = enhanced_settings.monitorMode === 0;
-    monitor.updateValues(data)
-}, 1000)
-
 // Streaming Monitor (Menu Icon)
 var enhanced_Monitor = document.createElement('div')
 enhanced_Monitor.className = 'R2s0be'
 enhanced_Monitor.id = 'enhanced_Monitor'
 enhanced_Monitor.innerHTML = `
-    <div role="button" class="CTvDXd QAAyWd Pjpac zcMYd CPNFX">
+    <style>
+      .loading {
+        pointer-events: none !important;
+        opacity: 0.3;
+      }
+      
+    </style>
+    <div role="button" class="CTvDXd QAAyWd Pjpac zcMYd CPNFX loading">
 
         <!-- Icon -->
         <span class="X5peoe" jsname="pYFhU">
@@ -551,6 +534,7 @@ enhanced_Monitor.innerHTML = `
         <span id="monitor-type" style="color: rgba(255,255,255,.4);font-size: 0.7rem; height: 0.5rem;"></span>        
     </div>
 `
+enhanced_Monitor.disabled = true
 enhanced_Monitor.style.cursor = 'pointer'
 enhanced_Monitor.style.userSelect = 'none'
 enhanced_Monitor.tabIndex = '0'
@@ -558,6 +542,10 @@ enhanced_Monitor.tabIndex = '0'
 // click on menu item "stream monitor"
 enhanced_Monitor.addEventListener('click', () => {
     const button = enhanced_Monitor
+    if (button.disabled) {
+        return
+    }
+
     const $icon = button.querySelector("span.X5peoe")
     const $typeDescription = button.querySelector("#monitor-type")
 
@@ -571,6 +559,42 @@ enhanced_Monitor.addEventListener('click', () => {
         $typeDescription.textContent = ""
     }
 });
+
+// Update Stream Elements
+setInterval(function () {
+    if (!isLocation('ingame')) {
+        monitor.reset()
+
+        // disable monitor-icon
+        enhanced_Monitor.disabled = true
+        const button = enhanced_Monitor.querySelector("div.CTvDXd")
+        button.classList.add("loading")
+
+        return
+    }
+
+    // Get local stream data
+    var enhanced_streamData = localStorage.getItem('enhanced_streamData');
+    if (enhanced_streamData == null) {
+        return;
+    }
+
+    const data = JSON.parse(enhanced_streamData)
+
+    // enable monitor-icon
+    enhanced_Monitor.disabled = false
+    const loadingElements = enhanced_Monitor.querySelectorAll(".loading")
+    console.log("elements found: " + loadingElements.length)
+    loadingElements.forEach(el => el.classList.remove("loading"))
+
+    if (enhanced_newMonitorPos != enhanced_settings.monitorPosition) {
+        var enhanced_newMonitorPos = enhanced_settings.monitorPosition
+        localStorage.setItem('enhanced_' + enhanced_settings.user, JSON.stringify(enhanced_settings))
+    }
+
+    let fullMode = enhanced_settings.monitorMode === 0;
+    monitor.updateValues(data)
+}, 1000)
 
 // Filter UI
 var enhanced_filterUI = {

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -495,13 +495,9 @@ enhanced_streamMonitor.addEventListener('dblclick', function () {
 document.body.appendChild(enhanced_streamMonitor)
 enhanced_dragElement(enhanced_streamMonitor)
 
-const menuMonitor = new MenuStreamMonitor(enhanced_lang)
-
-
 // Update Stream Elements
 setInterval(function () {
     if (!isLocation('ingame')) {
-        menuMonitor.reset()
         monitor.reset()
         return
     }
@@ -518,15 +514,6 @@ setInterval(function () {
         localStorage.setItem('enhanced_' + enhanced_settings.user, JSON.stringify(enhanced_settings))
     }
 
-    menuMonitor.updateContent(
-        data.codec,
-        data.resolution,
-        data.latency + " ms",
-        data.fps,
-        data.framedrop,
-        data.decode + " ms"
-    )
-
     let fullMode = enhanced_settings.monitorMode === 0;
     monitor.refreshContent(fullMode)
 }, 1000)
@@ -535,14 +522,42 @@ setInterval(function () {
 var enhanced_Monitor = document.createElement('div')
 enhanced_Monitor.className = 'R2s0be'
 enhanced_Monitor.id = 'enhanced_Monitor'
-enhanced_Monitor.innerHTML = '<div role="button" class="CTvDXd QAAyWd Pjpac zcMYd CPNFX"><span class="X5peoe" jsname="pYFhU"><i class="material-icons-extended" style="font-size: 2rem !important" aria-hidden="true">analytics</i></span><span class="caSJV" jsname="V67aGc">' + enhanced_lang.streammon + '</span></div>'
+enhanced_Monitor.innerHTML = `
+    <div role="button" class="CTvDXd QAAyWd Pjpac zcMYd CPNFX">
+
+        <!-- Icon -->
+        <span class="X5peoe" jsname="pYFhU">
+            <i class="material-icons-extended" style="font-size: 2rem !important" aria-hidden="true">analytics</i>
+        </span>
+        
+        <!-- Text -->
+        <span class="caSJV" jsname="V67aGc">${enhanced_lang.streammon}</span>
+        
+        <span id="monitor-type" style="color: rgba(255,255,255,.4);font-size: 0.7rem; display: none;">Standard</span>        
+    </div>
+`
 enhanced_Monitor.style.cursor = 'pointer'
 enhanced_Monitor.style.userSelect = 'none'
 enhanced_Monitor.tabIndex = '0'
 
 // click on menu item "stream monitor"
 enhanced_Monitor.addEventListener('click', () => {
-    monitor.toggle(enhanced_settings.monitorPosition)
+    const button = enhanced_Monitor
+    const $icon = button.querySelector("span.X5peoe")
+    const $typeDescription = button.querySelector("#monitor-type")
+
+    monitor.toggleMode(enhanced_settings.monitorPosition)
+
+    // update color
+    if (monitor.currentMode === "hidden") {
+        $icon.style.color = ""
+        $typeDescription.style.display = "none"
+    } else {
+        $icon.style.color = "#00e0ba"
+
+        $typeDescription.textContent = monitor.currentMode
+        $typeDescription.style.display = "block"
+    }
 });
 
 // double-click on menu item "stream monitor"
@@ -2751,7 +2766,7 @@ setInterval(function () {
             enhanced_monitorStarted = true
             enhanced_monitorState = 1
 
-            monitor.show(enhanced_settings.monitorPosition)
+            monitor.showAt(enhanced_settings.monitorPosition)
         }
 
         // Session Time
@@ -2761,7 +2776,7 @@ setInterval(function () {
             var enhanced_sessionDur = Date.now()
             enhanced_sessionDur = enhanced_formatTime((enhanced_sessionDur - enhanced_sessionStart) / 1000)
 
-            menuMonitor.updateSessionTime(enhanced_sessionDur)
+            monitor.updateSessionTime(enhanced_sessionDur)
         }
 
         // Discord Presence
@@ -2792,7 +2807,7 @@ setInterval(function () {
         }
 
         // Menu Monitor
-        secureInsert(menuMonitor.getElement(), '.FTrnxe:not(.qRvogc) > .OWVtN:not(.YgM2X)', 0)
+        secureInsert(monitor.menuElement, '.FTrnxe:not(.qRvogc) > .OWVtN:not(.YgM2X)', 0)
     } else {
         enhanced_discordPresence = {}
         enhanced_Windowed.style.display = 'none'
@@ -2811,7 +2826,7 @@ setInterval(function () {
 
         enhanced_monitorState === 0 ?
             monitor.hide() :
-            monitor.show(enhanced_settings.monitorPosition)
+            monitor.showAt(enhanced_settings.monitorPosition)
     }
 
     // Location - Captures
@@ -3371,7 +3386,7 @@ function enhanced_applySettings(set, opt) {
                     break
             }
             break
-        case 'monitorautostart':
+        case 'monitorautostart': // stadia menu (home)
             switch (opt) {
                 case 0:
                     enhanced_monitorAutostart.style.color = ''

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -18,6 +18,8 @@ const username = enhanced_AccountInfo[0] + '#' + enhanced_AccountInfo[1]
 var enhanced_extId = 'ldeakaihfnkjmelifgmbmjlphdfncbfg'
 var enhanced_lang = loadTranslations(enhanced_local)
 
+const streamDataService = new StreamDataService()
+
 // Load existing settings
 const settingsService = new SettingsService(username)
 var enhanced_storedSettings = settingsService.getSettings()
@@ -534,12 +536,10 @@ setInterval(function () {
     }
 
     // Get local stream data
-    var enhanced_streamData = localStorage.getItem('enhanced_streamData');
+    const enhanced_streamData = streamDataService.getData();
     if (enhanced_streamData == null) {
         return;
     }
-
-    const data = JSON.parse(enhanced_streamData)
 
     monitor.enableIcon()
 
@@ -549,7 +549,7 @@ setInterval(function () {
     }
 
     if (monitor.isVisible()) {
-        monitor.updateValues(data)
+        monitor.updateValues(enhanced_streamData)
         monitor.showMode(monitor.currentMode)
     }
 }, 1000)

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -584,7 +584,6 @@ setInterval(function () {
     // enable monitor-icon
     enhanced_Monitor.disabled = false
     const loadingElements = enhanced_Monitor.querySelectorAll(".loading")
-    console.log("elements found: " + loadingElements.length)
     loadingElements.forEach(el => el.classList.remove("loading"))
 
     if (enhanced_newMonitorPos != enhanced_settings.monitorPosition) {
@@ -594,6 +593,7 @@ setInterval(function () {
 
     let fullMode = enhanced_settings.monitorMode === 0;
     monitor.updateValues(data)
+    monitor.showMode(monitor.currentMode)
 }, 1000)
 
 // Filter UI

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -4121,19 +4121,6 @@ function enhanced_updateSettings(obj) {
     localStorage.setItem('enhanced_' + enhanced_settings.user, JSON.stringify(enhanced_settings))
 }
 
-/**
- * The setting key "monitorMode" (0/1) is used persist the current mode of the streaming monitor. In the previous
- * version, these modes were 0=Standard and 1=Compact. With this version we are introducing two more modes
- * 2=Menu and 9=Hidden/Off. We keep using numbers for this to prevent an immediate migration. However, We should migrate
- * these numbers to string values to their associated string values in the future. That is why the number conversion is
- * done in this method, so it can be removed quickly in a future update.
- *
- * Mode values:
- *  0 = Standard
- *  1 = Compact
- *  2 = Menu
- *  9 = Hidden/Off
- */
 function enhanced_saveMonitorMode(mode) {
     console.debug(`Saving monitor mode '${mode}'`)
 

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -3822,6 +3822,9 @@ function enhanced_applySettings(set, opt) {
                 showActive(translations.streammonmodemenu || "Menu")
                 break
         }
+
+        monitor.showMode(option)
+
         enhanced_log(`Stream Monitor Start: Set to "${option}".`)
 
         function showInactive() {

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -486,7 +486,7 @@ chrome.runtime.onMessage.addListener(function (info, sender, sendResponse) {
 
 var enhanced_monitorState = 0
 
-const monitor = new StreamMonitor(settingsService, enhanced_lang, enhanced_settings.monitorPosition, enhanced_settings.monitorAutostart === 1)
+const monitor = new StreamMonitor(settingsService, enhanced_lang, enhanced_settings.monitorPosition)
 
 const enhanced_streamMonitor = monitor.getElement();
 
@@ -531,7 +531,7 @@ enhanced_monitorButton.addEventListener('click', () => {
 // Update Stream Elements
 setInterval(function () {
     if (!isLocation('ingame')) {
-        monitor.reset(enhanced_settings.monitorAutostart)
+        monitor.reset(settingsService.getMonitorAutoStart())
         return
     }
 
@@ -1518,20 +1518,20 @@ enhanced_monitorAutostart.style.cursor = 'pointer'
 enhanced_monitorAutostart.style.userSelect = 'none'
 enhanced_monitorAutostart.tabIndex = '0'
 enhanced_monitorAutostart.addEventListener('click', function () {
+    const autoStartMode = settingsService.getMonitorAutoStart()
     let option
-    if (enhanced_settings.monitorAutostart === 0 || enhanced_settings.monitorAutostart === "Hidden") {
-        option = "Standard"
-    } else if (enhanced_settings.monitorAutostart === 1 || enhanced_settings.monitorAutostart === "Standard") {
-        option = "Compact"
-    } else if (enhanced_settings.monitorAutostart === "Compact") {
-        option = "Menu"
+    if (autoStartMode === 0 || autoStartMode === monitor.MODE.HIDDEN) {
+        option = monitor.MODE.STANDARD
+    } else if (autoStartMode === 1 || autoStartMode === monitor.MODE.STANDARD) {
+        option = monitor.MODE.COMPACT
+    } else if (autoStartMode === monitor.MODE.COMPACT) {
+        option = monitor.MODE.MENU
     } else {
-        option = "Hidden"
+        option = monitor.MODE.HIDDEN
     }
 
-    // persist settings
-    enhanced_settings.monitorAutostart = option
-    localStorage.setItem('enhanced_' + enhanced_settings.user, JSON.stringify(enhanced_settings))
+    enhanced_settings.monitorAutostart = option // updates current settings, used in other parts of the code
+    settingsService.saveMonitorAutoStart(option)
 
     // update ui
     enhanced_applySettings('monitorautostart', option)

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -486,7 +486,7 @@ chrome.runtime.onMessage.addListener(function (info, sender, sendResponse) {
 
 var enhanced_monitorState = 0
 
-const monitor = new StreamMonitor(settingsService, enhanced_lang, enhanced_settings.monitorMode, enhanced_settings.monitorPosition)
+const monitor = new StreamMonitor(settingsService, enhanced_lang, enhanced_settings.monitorPosition, enhanced_settings.monitorAutostart === 1)
 
 const enhanced_streamMonitor = monitor.getElement();
 

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -25,54 +25,18 @@ const settingsService = new SettingsService(username)
 var enhanced_storedSettings = settingsService.getSettings()
 
 // Default settings
-var enhanced_settings = {
-    user: username,
-    version: '0.0.0',
-    avatar: '',
-
-    monitorMode: 9, // 0=Standard, 1=Compact, 2=Menu, 9=Hidden/Off
-    monitorAutostart: 0, // 0=don't show on startup, 1=show on startup
-    monitorPosition: '1rem|1rem', // top + "|" + left
-
-    clockMode: 0,
-    clockOption: 0,
-    codec: 0,
-    resolution: 0,
-    gridSize: 0,
-    desktopWidth: screen.width,
-    desktopHeight: screen.height,
-    filter: 0,
-    hideMessagePreview: 0,
-    hideQuickReply: 0,
-    hideInlinePreview: 0,
-    hideOfflineUsers: 0,
-    hideInvisibleUsers: 0,
-    hideLabels: 0,
-    dimOverlay: 0,
-    hideUserMedia: 0,
-    hideCategories: 0,
-    splitStore: 0,
-    hideFamilySharing: 0,
-    enableShortcuts: 0,
-    enableStadiaDatabase: 1,
-    enableStadiaHunters: 0,
-    updateNotifications: 0,
-    streamMode: 0,
-    wishlist: "",
-    gameFilter: "",
-    favoriteList: "",
-    postprocess: {}
-}
+var enhanced_settings = settingsService.getDefaultSettings()
 
 // Merge settings
 if (enhanced_storedSettings) {
     const enhanced_oldSettings = enhanced_storedSettings
     enhanced_settings.version = enhanced_oldSettings.version
     enhanced_updateSettings(enhanced_oldSettings)
-    console.log('%cStadia Enhanced' + '%c ⚙️ - Profile: ' + enhanced_settings.user + ' loaded.', enhanced_consoleEnhanced, '')
+
+    enhanced_log(`Profile: ${enhanced_settings.user} loaded.`)
 } else {
-    console.log('%cStadia Enhanced' + '%c ⚙️ - Profile: Not found. Generating new profile with default values.', enhanced_consoleEnhanced, '')
     settingsService.saveSettings(enhanced_settings)
+    enhanced_log("Profile: Not found. Generating new profile with default values.")
 }
 
 // Check for updates
@@ -1519,10 +1483,12 @@ enhanced_monitorAutostart.style.userSelect = 'none'
 enhanced_monitorAutostart.tabIndex = '0'
 enhanced_monitorAutostart.addEventListener('click', function () {
     const autoStartMode = settingsService.getMonitorAutoStart()
+
+    // cycle through the available modes
     let option
-    if (autoStartMode === 0 || autoStartMode === monitor.MODE.HIDDEN) {
+    if (autoStartMode === monitor.MODE.HIDDEN) {
         option = monitor.MODE.STANDARD
-    } else if (autoStartMode === 1 || autoStartMode === monitor.MODE.STANDARD) {
+    } else if (autoStartMode === monitor.MODE.STANDARD) {
         option = monitor.MODE.COMPACT
     } else if (autoStartMode === monitor.MODE.COMPACT) {
         option = monitor.MODE.MENU
@@ -3311,8 +3277,8 @@ setInterval(function () {
 /**
  * Updates the home menu option corresponding to the specified "set" parameter.
  *
- * @param {string} set - Setting identifier: "codec", "resolution", "monitorautostart", ...
- * @param {number} opt - Option state represented by an integer
+ * @param {("codec"|"resolution"|"monitorautostart"|"notification"|"gridsize"|"clock"|"filter"|"messagepreview"|"quickreply"|"inlinepreview"|"offlineusers"|"invisibleusers"|"gamelabel"|"dimoverlay"|"mediapreview"|"categorypreview"|"storelist"|"familysharing"|"shortcuts"|"stadiadatabase"|"stadiahunters"|"streammode"|"letterbox"|"avatar"|"favorite"|"resetall"|"updateall")} set - Setting identifier
+ * @param {number|string} opt - Option state represented by an integer
  */
 function enhanced_applySettings(set, opt) {
     switch (set) {
@@ -3776,7 +3742,7 @@ function enhanced_applySettings(set, opt) {
             enhanced_applySettings('usermedia', enhanced_settings.hideUserMedia)
             enhanced_applySettings('streammode', enhanced_settings.streamMode)
             enhanced_applySettings('categorypreview', enhanced_settings.hideCategories)
-            enhanced_applySettings('monitorautostart', enhanced_settings.monitorAutostart)
+            enhanced_applySettings('monitorautostart', settingsService.getMonitorAutoStart())
             enhanced_applySettings('storelist', enhanced_settings.splitStore)
             enhanced_applySettings('shortcuts', enhanced_settings.enableShortcuts)
             enhanced_applySettings('stadiadatabase', enhanced_settings.enableStadiaDatabase)

--- a/extension/enhanced.js
+++ b/extension/enhanced.js
@@ -1475,13 +1475,8 @@ enhanced_resolutionPopup.addEventListener('click', function () {
 })
 
 // Stream Monitor Autostart
-var enhanced_monitorAutostart = document.createElement('div')
-enhanced_monitorAutostart.className = 'pBvcyf QAAyWd'
-enhanced_monitorAutostart.id = 'enhanced_monitorAutostart'
-enhanced_monitorAutostart.style.cursor = 'pointer'
-enhanced_monitorAutostart.style.userSelect = 'none'
-enhanced_monitorAutostart.tabIndex = '0'
-enhanced_monitorAutostart.addEventListener('click', function () {
+const autoStartElement = new MonitorAutoStartOption(enhanced_lang)
+autoStartElement.onClick(function () {
     const autoStartMode = settingsService.getMonitorAutoStart()
 
     // cycle through the available modes
@@ -1502,7 +1497,7 @@ enhanced_monitorAutostart.addEventListener('click', function () {
     // update ui
     enhanced_applySettings('monitorautostart', option)
 })
-enhanced_settingsStream.append(enhanced_monitorAutostart)
+enhanced_settingsStream.append(autoStartElement.element)
 
 // Grid - Control element for the homescreen library grid
 var enhanced_Grid = document.createElement('div')
@@ -3770,68 +3765,26 @@ function enhanced_applySettings(set, opt) {
      * integer value of 0 or 1 (legacy)
      */
     function _applyMonitorAutoStart(translations, option) {
-        const COLOR_ACTIVE = "#00e0ba"
-
         switch (option) {
             case 0: // legacy support
             case "Hidden":
-                showInactive();
+                autoStartElement.setInactive()
                 break
             case 1: // legacy support
             case "Standard":
-                showActive(translations.streammonmodestandard || "Standard")
+                autoStartElement.setActive(translations.streammonmodestandard || "Standard")
                 break
             case "Compact":
-                showActive(translations.streammonmodecompact || "Compact")
+                autoStartElement.setActive(translations.streammonmodecompact || "Compact")
                 break
             case "Menu":
-                showActive(translations.streammonmodemenu || "Menu")
+                autoStartElement.setActive(translations.streammonmodemenu || "Menu")
                 break
         }
 
         monitor.showMode(option)
 
         enhanced_log(`Stream Monitor Start: Set to "${option}".`)
-
-        function showInactive() {
-            enhanced_monitorAutostart.style.color = ''
-            enhanced_monitorAutostart.innerHTML = `
-                
-                <!-- Icon -->
-                <i class="material-icons-extended STPv1" aria-hidden="true">settings_power</i>
-                
-                <span class="mJVLwb" style="width: calc(90% - 3rem); white-space: normal;">
-                    <!-- Title -->
-                    ${translations.streammon}: ${translations.manual}<br>
-                    
-                    <!-- Description -->
-                    <span style="color: #fff;font-size: 0.7rem;">${translations.streammondesc}</span><br>
-
-                    <!-- Default -->
-                    <span style="color: rgba(255,255,255,.4);font-size: 0.7rem;">${translations.default}: ${translations.manual}</span>
-                </span>
-            `
-        }
-
-        function showActive(modeTranslation) {
-            enhanced_monitorAutostart.style.color = COLOR_ACTIVE
-            enhanced_monitorAutostart.innerHTML = `
-                
-                <!-- Icon -->
-                <i class="material-icons-extended STPv1" aria-hidden="true">settings_power</i>
-                
-                <span class="mJVLwb" style="width: calc(90% - 3rem); white-space: normal;">
-                    <!-- Title -->
-                    ${translations.streammon}: ${modeTranslation}<br>
-                
-                    <!-- Description -->
-                    <span style="color: #fff;font-size: 0.7rem;">${translations.streammondesc}</span><br>
-    
-                    <!-- Default -->
-                    <span style="color: rgba(255,255,255,.4);font-size: 0.7rem;">${translations.default}: ${translations.manual}</span>
-                </span>
-            `
-        }
     }
 }
 

--- a/extension/main_menu.js
+++ b/extension/main_menu.js
@@ -1,0 +1,101 @@
+/**
+ * Element in the main extension menu for configuring the streaming monitor on startup.
+ */
+class MonitorAutoStartOption {
+    _COLOR_ACTIVE = "#00e0ba"
+
+    _translations;
+    _element;
+
+    /**
+     *
+     * @param {Object} translations
+     * @param {string} translations.streammon
+     * @param {string} translations.streammondesc
+     * @param {string} translations.manual
+     * @param {string} translations.default
+     */
+    constructor(translations) {
+        this._translations = translations
+        this._element = this._createElement()
+    }
+
+    /**
+     * @returns {HTMLDivElement}
+     */
+    get element() {
+        return this._element;
+    }
+
+    setInactive() {
+        this._updateColor("")
+        this._updateContent(
+            `  
+                <!-- Icon -->
+                <i class="material-icons-extended STPv1" aria-hidden="true">settings_power</i>
+                
+                <span class="mJVLwb" style="width: calc(90% - 3rem); white-space: normal;">
+                    <!-- Title -->
+                    ${this._translations.streammon}: ${this._translations.manual}<br>
+                    
+                    <!-- Description -->
+                    <span style="color: #fff;font-size: 0.7rem;">${this._translations.streammondesc}</span><br>
+
+                    <!-- Default -->
+                    <span style="color: rgba(255,255,255,.4);font-size: 0.7rem;">${this._translations.default}: ${this._translations.manual}</span>
+                </span>
+            `
+        )
+    }
+
+    /**
+     * @param {string} modeTranslation
+     */
+    setActive(modeTranslation) {
+        this._updateColor(this._COLOR_ACTIVE)
+        this._updateContent(
+            `
+                <!-- Icon -->
+                <i class="material-icons-extended STPv1" aria-hidden="true">settings_power</i>
+                
+                <span class="mJVLwb" style="width: calc(90% - 3rem); white-space: normal;">
+                    <!-- Title -->
+                    ${this._translations.streammon}: ${modeTranslation}<br>
+                
+                    <!-- Description -->
+                    <span style="color: #fff;font-size: 0.7rem;">${this._translations.streammondesc}</span><br>
+    
+                    <!-- Default -->
+                    <span style="color: rgba(255,255,255,.4);font-size: 0.7rem;">${this._translations.default}: ${this._translations.manual}</span>
+                </span>
+            `
+        )
+    }
+
+    /**
+     *
+     * @param {function(): void} fn
+     */
+    onClick(fn) {
+        this._element.addEventListener("click", fn)
+    }
+
+    _createElement() {
+        const element = document.createElement('div');
+        element.id = 'enhanced_monitorAutostart'
+        element.className = 'pBvcyf QAAyWd'
+        element.style.cursor = 'pointer'
+        element.style.userSelect = 'none'
+        element.tabIndex = '0'
+
+        return element
+    }
+
+    _updateColor(color) {
+        this._element.style.color = color
+    }
+
+    _updateContent(html) {
+        this._element.innerHTML = html
+    }
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -52,6 +52,7 @@
             "translations/sk.js",
             "translations/sv.js",
 
+            "settings.js",
             "translations.js",
             "monitor.js",
             "menu_monitor.js",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -55,6 +55,7 @@
             "settings.js",
             "data.js",
             "translations.js",
+            "main_menu.js",
             "monitor.js",
             "menu_monitor.js",
             "enhanced.js"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -53,6 +53,7 @@
             "translations/sv.js",
 
             "settings.js",
+            "data.js",
             "translations.js",
             "monitor.js",
             "menu_monitor.js",

--- a/extension/menu_monitor.js
+++ b/extension/menu_monitor.js
@@ -16,6 +16,10 @@ class MenuStreamMonitor {
         console.debug("Initializing Menu Stream Monitor...")
         this.translations = translations
         this.element = this._createElement()
+
+        // insert
+        // document.querySelector(".FTrnxe:not(.qRvogc) > .OWVtN:not(.YgM2X)").append(this.element)
+        // secureInsert(monitor.menuElement, '.FTrnxe:not(.qRvogc) > .OWVtN:not(.YgM2X)', 0)
     }
 
     updateSessionTime(duration) {

--- a/extension/menu_monitor.js
+++ b/extension/menu_monitor.js
@@ -38,13 +38,21 @@ class MenuStreamMonitor {
         this.updateContent("-", "-", "-", "-", "-")
     }
 
+    show() {
+        this.element.style.display = "block"
+    }
+
+    hide() {
+        this.element.style.display = "none"
+    }
+
     getElement() {
         return this.element
     }
 
     _createElement() {
-        const element = document.createElement('div');
-        element.style.whiteSpace = 'nowrap'
+        const element = document.createElement("div");
+        element.style.whiteSpace = "nowrap"
 
         element.innerHTML = `
             ${this._createMenuEntry(this.SESSION_TIME_ID, this.translations.sessiontime, "-")}

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -538,6 +538,9 @@ class StreamMonitor {
         `
     }
 
+    /**
+     * @param {string} positionString - Top and left pixels divided by a pipe (e.g "1rem|1rem")
+     */
     _setPositionFromString(positionString) {
         const positionTokens = positionString.split("|")
 

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -337,7 +337,7 @@ class StreamMonitor {
                 
                 <div class="grid">
                     <!-- Codec -->
-                    <span>${this.translations.codec}</span><span>${data.codec | "-"}</span>
+                    <span>${this.translations.codec}</span><span>${data.codec || "-"}</span>
                     <span></span>
                     
                     <!-- Resolution -->

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -17,6 +17,11 @@ class StreamMonitor {
     COLOR_GOOD = "#00E0BA" // green
     COLOR_PERFECT = "#44BBD8" // blue
 
+    /**
+     * Enum for available monitor modes.
+     * @readonly
+     * @enum {string}
+     */
     _MODE = {
         standard: "Standard",
         compact: "Compact",
@@ -35,9 +40,9 @@ class StreamMonitor {
      * @param {SettingsService} settingsService - used for persisting monitor-related settings
      * @param {translation[]} translations
      * @param {string} initialPosition - position on screen where the monitor should be shown
-     * @param {boolean} autoStartEnabled - if monitor should be automatically shown on startup
+     * @param {("Standard"|"Compact"|"Menu"|"Hidden")} autoStartMode
      */
-    constructor(settingsService, translations, initialPosition, autoStartEnabled) {
+    constructor(settingsService, translations, initialPosition, autoStartMode) {
         console.debug("Initializing Stream Monitor...")
         this._settingsService = settingsService
         this.translations = translations
@@ -49,12 +54,12 @@ class StreamMonitor {
         this._iconElement = this._createIconElement()
 
         this._setPositionFromString(initialPosition)
-        this.reset(autoStartEnabled)
+        this.reset(autoStartMode)
 
         const initialMode = this._settingsService.getMonitorMode();
         const isLegacyMode = Number.isInteger(initialMode)
 
-        if (isLegacyMode && autoStartEnabled) {
+        if (isLegacyMode && autoStartMode !== this._MODE.hidden) {
             const legacyMode = this._modeFromSettingsNumber(initialMode)
             this._currentMode = legacyMode
 
@@ -62,8 +67,8 @@ class StreamMonitor {
         }
 
         this._currentMode = initialMode
-        if (autoStartEnabled && initialMode === this._MODE.hidden) {
-            this._switchToStandard()
+        if (initialMode === this._MODE.hidden && autoStartMode !== this._MODE.hidden) {
+            this.showMode(autoStartMode)
         }
 
         this._updateIcon(this._currentMode)
@@ -92,16 +97,16 @@ class StreamMonitor {
     }
 
     /**
-     * @param {boolean} autoStartEnabled - if monitor should be automatically shown on startup
+     * @param {("Standard"|"Compact"|"Menu"|"Hidden")} autoStartMode
      */
-    reset(autoStartEnabled) {
+    reset(autoStartMode) {
         this.updateValues(null)
 
         this._menuElement.reset()
 
-        if (this._currentMode === this._MODE.hidden && autoStartEnabled) {
-            console.debug(`Overwriting monitor mode to "${this._MODE.standard}" because of enabled autostart`)
-            this._switchToStandard()
+        if (this._currentMode === this._MODE.hidden && autoStartMode !== this._MODE.hidden) {
+            console.debug(`Overwriting monitor mode to "${autoStartMode}" because of enabled autostart`)
+            this.showMode(autoStartMode)
         }
 
         this._disableIcon()
@@ -303,27 +308,27 @@ class StreamMonitor {
                     <span style="grid-column: 1 / 4;">
                     
                         <!-- Codec -->
-                        <span class="monitor-codec">${data.codec}</span>
+                        <span class="monitor-codec">${ data != null ? data.codec : ""}</span>
                         <div class="split">|</div>
 
                         <!-- Resolution -->
-                        ${data.resolution}
+                        ${data != null ? data.resolution : ""}
                         <div class="split">|</div>
 
                         <!-- FPS -->                        
-                        ${data.fps} fps
+                        ${data != null ? data.fps : ""} fps
                          <div class="split">|</div>
 
                         <!-- Latency -->
-                        <span class="monitor-latency">${data.latency}</span> ms
+                        <span class="monitor-latency">${data != null ? data.latency : ""}</span> ms
                         <div class="split">|</div>
 
                         <!-- Decoding time -->                        
-                        ${data.decode} ms
+                        ${data != null ? data.decode : ""} ms
                         <div class="split">|</div>
 
                         <!-- Connection -->
-                        <span style="color: ${(this._calculateConnectionColor(data.fps, data.decode, data.framedropPerc, data.latency))};">⬤</span>
+                        <span style="color: ${data != null ? (this._calculateConnectionColor(data.fps, data.decode, data.framedropPerc, data.latency)) : ""};">⬤</span>
                     </span>
                 </div>
             </section>

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -17,12 +17,10 @@ class StreamMonitor {
     COLOR_PERFECT = "#44BBD8" // blue
 
     _MODE = {
-        hidden: "Hidden",
-        standard: "Standard",
-        compact: "Compact",
-        menu: "Menu"
-        // standalone
-        // chart
+        standard: "Standard", // 0
+        compact: "Compact", // 1
+        menu: "Menu", // 2
+        hidden: "Hidden" // 9
     }
 
     translations;
@@ -31,7 +29,7 @@ class StreamMonitor {
     _currentMode;
     _currentData; // convert to array for chart
 
-    constructor(translations, initialPosition) {
+    constructor(translations, initialMode, initialPosition) {
         console.debug("Initializing Stream Monitor...")
         this.translations = translations
 
@@ -42,7 +40,13 @@ class StreamMonitor {
         this._setPositionFromString(initialPosition)
         this.reset()
 
-        this._currentMode = this._MODE.hidden
+        const isLegacy = Number.isInteger(initialMode)
+
+        this._currentMode = isLegacy
+            ? this._modeFromSettingsNumber(initialMode)
+            : initialMode
+
+        console.debug("Setting initial mode to: " + this.currentMode)
     }
 
     // Used as monitorPosition (stored in settings)
@@ -502,5 +506,18 @@ class StreamMonitor {
 
     _positionAsString() {
         return this.element.style.top + '|' + this.element.style.left
+    }
+
+    _modeFromSettingsNumber(settingsNumber) {
+        switch (settingsNumber) {
+            case 0:
+                return this._MODE.standard
+            case 1:
+                return this._MODE.compact
+            case 2:
+                return this._MODE.menu
+            default:
+                return this._MODE.hidden
+        }
     }
 }

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -38,8 +38,33 @@ class StreamMonitor {
     _isInGame = false; // holds current state
 
     /**
+     * @typedef {Object} Translations
+     * @property {string} hardware
+     * @property {string} software
+     * @property {string} stream
+     * @property {string} codec
+     * @property {string} resolution
+     * @property {string} decodetime
+     * @property {string} framedrop
+     * @property {string} session
+     * @property {string} date
+     * @property {string} time
+     * @property {string} sessiontime
+     * @property {string} network
+     * @property {string} trafficsession
+     * @property {string} trafficcurrent
+     * @property {string} trafficaverage
+     * @property {string} packetloss
+     * @property {string} latency
+     * @property {string} jitter
+     * @property {string} streammonmodestandard
+     * @property {string} streammonmodecompact
+     * @property {string} streammonmodemenu
+     */
+
+    /**
      * @param {SettingsService} settingsService - used for persisting monitor-related settings
-     * @param {translation[]} translations
+     * @param {Translations} translations
      * @param {string} initialPosition - position on screen where the monitor should be shown
      */
     constructor(settingsService, translations, initialPosition) {
@@ -673,7 +698,16 @@ class StreamMonitor {
         const $typeDescription = this._iconElement.querySelector("#monitor-type")
 
         $icon.style.color = mode === this.MODE.HIDDEN ? "" : "#00e0ba"
-        $typeDescription.textContent = mode === this.MODE.HIDDEN ? "" : mode
+        $typeDescription.textContent = this._textForMode(mode)
+    }
+
+    _textForMode(mode) {
+        switch (mode) {
+            case this.MODE.STANDARD: return this._translations.streammonmodestandard || "Standard";
+            case this.MODE.COMPACT: return this._translations.streammonmodecompact || "Compact";
+            case this.MODE.MENU: return this._translations.streammonmodemenu || "Menu";
+            default: return "";
+        }
     }
 
     _disableIcon() {

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -100,7 +100,6 @@ class StreamMonitor {
 
     // every second or so
     updateValues(data) {
-        console.log("update value:" + data)
         this.ensurePosition();
 
         data.codec = data.codec
@@ -208,7 +207,6 @@ class StreamMonitor {
     }
 
     _createFull(data) {
-        console.log("update standard mode: " + data.decodetime + " ms, " + data.fps)
         return `
             ${this._createSessionSection(data.date, data.time, data.sessiontime)}
             ${this._createStreamSection(data)}

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -30,7 +30,7 @@ class StreamMonitor {
     }
 
     _settingsService;
-    translations;
+    _translations;
     element;
 
     _currentMode;
@@ -45,7 +45,7 @@ class StreamMonitor {
     constructor(settingsService, translations, initialPosition) {
         console.debug("Initializing Stream Monitor...")
         this._settingsService = settingsService
-        this.translations = translations
+        this._translations = translations
 
         this.element = this._createElement()
         this._menuElement = new MenuStreamMonitor(translations)
@@ -171,8 +171,8 @@ class StreamMonitor {
         this.ensurePosition();
 
         data.codec = data.codec
-            .replace("Hardware", this.translations.hardware)
-            .replace("Software", this.translations.software)
+            .replace("Hardware", this._translations.hardware)
+            .replace("Software", this._translations.software)
 
         switch (this._currentMode) {
             case this.MODE.STANDARD:
@@ -299,6 +299,15 @@ class StreamMonitor {
         this._menuElement.show()
     }
 
+    /**
+     * @param {Object|null} data
+     * @param {("Hardware H264"|"Hardware VP9"|"Software VP9")} data.codec - The video compression standard used
+     * @param {string} data.resolution
+     * @param {number} data.fps
+     * @param {number} data.latency
+     * @param {number} data.decode
+     * @param {number} data.frameDropPerc
+     */
     _createFull(data) {
         if (data == null) {
             return ""
@@ -311,6 +320,15 @@ class StreamMonitor {
         `
     }
 
+    /**
+     * @param {Object|null} data
+     * @param {("Hardware H264"|"Hardware VP9"|"Software VP9")} data.codec - The video compression standard used
+     * @param {string} data.resolution
+     * @param {number} data.fps
+     * @param {number} data.latency
+     * @param {number} data.decode
+     * @param {number} data.frameDropPerc
+     */
     _createSimple(data) {
         return `
             <section id="monitor_simple">
@@ -345,9 +363,15 @@ class StreamMonitor {
         `
     }
 
+    /**
+     * @param {number} fps
+     * @param {number} decode
+     * @param {number} frameDropPerc
+     * @param {number} latency
+     */
     _calculateConnectionColor(fps, decode, frameDropPerc, latency) {
-        if (parseInt(fps) < 1) {
-            return 'white'
+        if (fps < 1) {
+            return "white"
         }
 
         if (decode > 12 || frameDropPerc > 1 || latency > 100) {
@@ -365,6 +389,9 @@ class StreamMonitor {
         return this.COLOR_PERFECT
     }
 
+    /**
+     * @param {number} decode
+     */
     _calculateDecodeColor(decode) {
         if (decode > 12) {
             return this.COLOR_VERY_BAD
@@ -381,6 +408,9 @@ class StreamMonitor {
         return this.COLOR_PERFECT
     }
 
+    /**
+     * @param {number} frameDropPerc
+     */
     _calculateFrameDropColor(frameDropPerc) {
         if (frameDropPerc > 1) {
             return this.COLOR_VERY_BAD
@@ -397,6 +427,9 @@ class StreamMonitor {
         return this.COLOR_PERFECT
     }
 
+    /**
+     * @param {number} latency
+     */
     _calculateLatencyColor(latency) {
         if (latency > 100) {
             return this.COLOR_VERY_BAD;
@@ -425,20 +458,31 @@ class StreamMonitor {
         return this.element.style.display === "none"
     }
 
+    /**
+     * @param {Object|null} data
+     * @param {("Hardware H264"|"Hardware VP9"|"Software VP9")} data.codec - The video compression standard used
+     * @param {string} data.resolution
+     * @param {number} data.fps
+     * @param {number} data.latency
+     * @param {number} data.decode
+     * @param {string} data.framedrop
+     * @param {number} data.framedropPerc
+     * @param {string} data.compression
+     */
     _createStreamSection(data) {
         return `
             <section>
                 <!-- Header -->
-                <div class="tag">${this.translations.stream}</div>
+                <div class="tag">${this._translations.stream}</div>
                 
                 <div class="grid">
                     <!-- Codec -->
-                    <span>${this.translations.codec}</span><span>${data.codec || "-"}</span>
+                    <span>${this._translations.codec}</span><span>${data.codec || "-"}</span>
                     <span></span>
                     
                     <!-- Resolution -->
                     <div class="border"></div>
-                    <span>${this.translations.resolution}</span>
+                    <span>${this._translations.resolution}</span>
                     <span>${data.resolution}</span>
                     <span></span>
                     
@@ -449,17 +493,17 @@ class StreamMonitor {
                     <span></span>
                     
                     <!-- Compression (if VP9 ) -->
-                    ${this._createCompression(data)}
+                    ${this._createCompression(data.codec, data.compression)}
 
                     <!-- Decode -->
                     <div class="border"></div>
-                    <span>${this.translations.decodetime}</span>
+                    <span>${this._translations.decodetime}</span>
                     <span>${data.decode} ms</span>
                     <span class="connection" style="color: ${(this._calculateDecodeColor(data.decode))};">⬤</span>
                     
                     <!-- Framedrop -->
                     <div class="border"></div>
-                    <span>${this.translations.framedrop}</span>
+                    <span>${this._translations.framedrop}</span>
                     <span>${data.framedrop}</span>
                     <span class="connection" style="color: ${(this._calculateFrameDropColor(data.framedropPerc))};">⬤</span>
                     
@@ -472,21 +516,21 @@ class StreamMonitor {
         return `
             <section>           
                 <!-- Header -->    
-                <div class="tag">${this.translations.session}</div>
+                <div class="tag">${this._translations.session}</div>
                 
                 <div class="grid">
                     <!-- Date -->
-                    <span>${this.translations.date}</span><span>${date}</span>
+                    <span>${this._translations.date}</span><span>${date}</span>
                     <span></span>
                     
                     <!-- Time -->
                     <div class="border"></div>                    
-                    <span>${this.translations.time}</span><span>${time}</span>
+                    <span>${this._translations.time}</span><span>${time}</span>
                     <span></span>
 
                     <!-- Session time -->
                     <div class="border"></div>
-                    <span>${this.translations.sessiontime}</span><span>${sessionDuration}</span>
+                    <span>${this._translations.sessiontime}</span><span>${sessionDuration}</span>
                     <span></span>
                     
                 </div>
@@ -498,39 +542,39 @@ class StreamMonitor {
         return `
             <section>
                 <!-- Header -->
-                <div class="tag">${this.translations.network}</div>
+                <div class="tag">${this._translations.network}</div>
 
                 <div class="grid">
                     <!-- Session Traffic -->
-                    <span>${this.translations.trafficsession}</span>
+                    <span>${this._translations.trafficsession}</span>
                     <span>${data.sessionTraffic}</span>
                     <span></span>
                     
                     <!-- Current Traffic -->
                     <div class="border"></div>
-                    <span>${this.translations.trafficcurrent}</span>
+                    <span>${this._translations.trafficcurrent}</span>
                     <span>${data.currentTraffic}</span>
                     <span></span>
                     
                     <!-- Avg Traffic -->
                     <div class="border"></div>
-                    <span>${this.translations.trafficaverage}</span>
+                    <span>${this._translations.trafficaverage}</span>
                     <span>${data.averageTraffic}</span>
                     <span></span>
                     
                     <!-- Packetloss -->
                     <div class="border"></div>
-                    <span>${this.translations.packetloss}</span>
+                    <span>${this._translations.packetloss}</span>
                     <span>${data.packetloss}</span>
                     <span></span>
                     
                     <!-- Latency -->
                     <div class="border"></div>
-                    <span>${this.translations.latency}</span><span>${data.latency} ms</span><span class="connection" style="color: ${(this._calculateLatencyColor(data.latency))};">⬤</span>
+                    <span>${this._translations.latency}</span><span>${data.latency} ms</span><span class="connection" style="color: ${(this._calculateLatencyColor(data.latency))};">⬤</span>
                     
                     <!-- Jitter -->
                     <div class="border"></div>
-                    <span>${this.translations.jitter}</span>
+                    <span>${this._translations.jitter}</span>
                     <span>${data.jitter}</span>
                     <span></span>
                    
@@ -539,15 +583,19 @@ class StreamMonitor {
         `
     }
 
-    _createCompression(data) {
-        if (!data.codec.includes('VP9')) {
+    /**
+     * @param {string} codec
+     * @param {string} compression
+     */
+    _createCompression(codec, compression) {
+        if (!codec.includes("VP9")) {
             return ""
         }
 
         return `
             <div class="border"></div>
-            <span>${this.translations.compression}</span>
-            <span>${data.compression}</span>
+            <span>${this._translations.compression}</span>
+            <span>${compression}</span>
             <span></span>
         `
     }

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -22,11 +22,11 @@ class StreamMonitor {
      * @readonly
      * @enum {string}
      */
-    _MODE = {
-        standard: "Standard",
-        compact: "Compact",
-        menu: "Menu",
-        hidden: "Hidden"
+    MODE = {
+        STANDARD: "Standard",
+        COMPACT: "Compact",
+        MENU: "Menu",
+        HIDDEN: "Hidden"
     }
 
     _settingsService;
@@ -40,9 +40,8 @@ class StreamMonitor {
      * @param {SettingsService} settingsService - used for persisting monitor-related settings
      * @param {translation[]} translations
      * @param {string} initialPosition - position on screen where the monitor should be shown
-     * @param {("Standard"|"Compact"|"Menu"|"Hidden")} autoStartMode
      */
-    constructor(settingsService, translations, initialPosition, autoStartMode) {
+    constructor(settingsService, translations, initialPosition) {
         console.debug("Initializing Stream Monitor...")
         this._settingsService = settingsService
         this.translations = translations
@@ -54,12 +53,14 @@ class StreamMonitor {
         this._iconElement = this._createIconElement()
 
         this._setPositionFromString(initialPosition)
+
+        const autoStartMode = settingsService.getMonitorAutoStart()
         this.reset(autoStartMode)
 
         const initialMode = this._settingsService.getMonitorMode();
         const isLegacyMode = Number.isInteger(initialMode)
 
-        if (isLegacyMode && autoStartMode !== this._MODE.hidden) {
+        if (isLegacyMode && autoStartMode !== this.MODE.HIDDEN) {
             const legacyMode = this._modeFromSettingsNumber(initialMode)
             this._currentMode = legacyMode
 
@@ -67,7 +68,7 @@ class StreamMonitor {
         }
 
         this._currentMode = initialMode
-        if (initialMode === this._MODE.hidden && autoStartMode !== this._MODE.hidden) {
+        if (initialMode === this.MODE.HIDDEN && autoStartMode !== this.MODE.HIDDEN) {
             this.showMode(autoStartMode)
         }
 
@@ -104,7 +105,7 @@ class StreamMonitor {
 
         this._menuElement.reset()
 
-        if (this._currentMode === this._MODE.hidden && autoStartMode !== this._MODE.hidden) {
+        if (this._currentMode === this.MODE.HIDDEN && autoStartMode !== this.MODE.HIDDEN) {
             console.debug(`Overwriting monitor mode to "${autoStartMode}" because of enabled autostart`)
             this.showMode(autoStartMode)
         }
@@ -114,16 +115,16 @@ class StreamMonitor {
 
     toggleMode() {
         switch (this._currentMode) {
-            case this._MODE.hidden:
+            case this.MODE.HIDDEN:
                 this._switchToStandard()
                 break
-            case this._MODE.standard:
+            case this.MODE.STANDARD:
                 this._switchToCompact()
                 break
-            case this._MODE.compact:
+            case this.MODE.COMPACT:
                 this._switchToMenu()
                 break
-            case this._MODE.menu:
+            case this.MODE.MENU:
                 this._switchToHidden()
                 break
         }
@@ -131,16 +132,16 @@ class StreamMonitor {
 
     showMode(mode) {
         switch (mode) {
-            case this._MODE.standard:
+            case this.MODE.STANDARD:
                 this._switchToStandard()
                 break
-            case this._MODE.compact:
+            case this.MODE.COMPACT:
                 this._switchToCompact()
                 break
-            case this._MODE.menu:
+            case this.MODE.MENU:
                 this._switchToMenu()
                 break
-            case this._MODE.hidden:
+            case this.MODE.HIDDEN:
                 this._switchToHidden()
                 break
         }
@@ -165,15 +166,15 @@ class StreamMonitor {
             .replace("Software", this.translations.software)
 
         switch (this._currentMode) {
-            case this._MODE.standard:
+            case this.MODE.STANDARD:
                 this.element.innerHTML = this._createFull(data)
                 break
 
-            case this._MODE.compact:
+            case this.MODE.COMPACT:
                 this.element.innerHTML = this._createSimple(data)
                 break
 
-            case this._MODE.menu:
+            case this.MODE.MENU:
                 this._menuElement.updateContent(
                     data.codec,
                     data.resolution,
@@ -202,7 +203,7 @@ class StreamMonitor {
     }
 
     isVisible() {
-        return this._currentMode !== this._MODE.hidden
+        return this._currentMode !== this.MODE.HIDDEN
     }
 
     getElement() {
@@ -225,37 +226,37 @@ class StreamMonitor {
     _switchToStandard() {
         this.ensurePosition();
         this._showStandard()
-        this._updateIcon(this._MODE.standard)
-        this._settingsService.saveMonitorMode(this._MODE.standard)
+        this._updateIcon(this.MODE.STANDARD)
+        this._settingsService.saveMonitorMode(this.MODE.STANDARD)
 
-        this._currentMode = this._MODE.standard
+        this._currentMode = this.MODE.STANDARD
     }
 
     _switchToCompact() {
         this.ensurePosition();
         this._showCompact(this._currentData)
-        this._updateIcon(this._MODE.compact)
-        this._settingsService.saveMonitorMode(this._MODE.compact)
+        this._updateIcon(this.MODE.COMPACT)
+        this._settingsService.saveMonitorMode(this.MODE.COMPACT)
 
-        this._currentMode = this._MODE.compact
+        this._currentMode = this.MODE.COMPACT
     }
 
     _switchToMenu() {
         this.hide()
         this._showMenu(this._currentData)
-        this._updateIcon(this._MODE.menu)
-        this._settingsService.saveMonitorMode(this._MODE.menu)
+        this._updateIcon(this.MODE.MENU)
+        this._settingsService.saveMonitorMode(this.MODE.MENU)
 
-        this._currentMode = this._MODE.menu
+        this._currentMode = this.MODE.MENU
     }
 
     _switchToHidden() {
         this.hide()
         this._menuElement.hide()
-        this._updateIcon(this._MODE.hidden)
-        this._settingsService.saveMonitorMode(this._MODE.hidden)
+        this._updateIcon(this.MODE.HIDDEN)
+        this._settingsService.saveMonitorMode(this.MODE.HIDDEN)
 
-        this._currentMode = this._MODE.hidden
+        this._currentMode = this.MODE.HIDDEN
     }
 
     _showStandard() {
@@ -563,13 +564,13 @@ class StreamMonitor {
     _modeFromSettingsNumber(settingsNumber) {
         switch (settingsNumber) {
             case 0:
-                return this._MODE.standard
+                return this.MODE.STANDARD
             case 1:
-                return this._MODE.compact
+                return this.MODE.COMPACT
             case 2:
-                return this._MODE.menu
+                return this.MODE.MENU
             default:
-                return this._MODE.hidden
+                return this.MODE.HIDDEN
         }
     }
 
@@ -614,8 +615,8 @@ class StreamMonitor {
         const $icon = this._iconElement.querySelector("span.X5peoe")
         const $typeDescription = this._iconElement.querySelector("#monitor-type")
 
-        $icon.style.color = mode === this._MODE.hidden ? "" : "#00e0ba"
-        $typeDescription.textContent = mode === this._MODE.hidden ? "" : mode
+        $icon.style.color = mode === this.MODE.HIDDEN ? "" : "#00e0ba"
+        $typeDescription.textContent = mode === this.MODE.HIDDEN ? "" : mode
     }
 
     _disableIcon() {

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -12,8 +12,8 @@ class StreamMonitor {
     ELEMENT_LATENCY_SELECTOR = ".monitor-latency"
 
     // Stadias Color Coding
-    COLOR_VERY_BAD = "#FF7070"; // red
-    COLOR_BAD = "#FFB83D"; // yellow
+    COLOR_VERY_BAD = "#FF7070" // red
+    COLOR_BAD = "#FFB83D" // yellow
     COLOR_GOOD = "#00E0BA" // green
     COLOR_PERFECT = "#44BBD8" // blue
 
@@ -35,6 +35,7 @@ class StreamMonitor {
 
     _currentMode;
     _currentData; // convert to array for chart
+    _isInGame = false; // holds current state
 
     /**
      * @param {SettingsService} settingsService - used for persisting monitor-related settings
@@ -101,16 +102,22 @@ class StreamMonitor {
      * @param {("Standard"|"Compact"|"Menu"|"Hidden")} autoStartMode
      */
     reset(autoStartMode) {
+        if (!this._isInGame) { // already reset, no need to do it again
+            return
+        }
+
         this.updateValues(null)
 
         this._menuElement.reset()
 
-        if (this._currentMode === this.MODE.HIDDEN && autoStartMode !== this.MODE.HIDDEN) {
+        // overwrite mode for next game startup if autoStart option has been set
+        if (autoStartMode !== this.MODE.HIDDEN) {
             console.debug(`Overwriting monitor mode to "${autoStartMode}" because of enabled autostart`)
             this.showMode(autoStartMode)
         }
 
         this._disableIcon()
+        this._isInGame = false
     }
 
     toggleMode() {
@@ -156,8 +163,10 @@ class StreamMonitor {
         this._currentData = data
 
         if (data == null) {
+            this._isInGame = false
             return
         }
+        this._isInGame = true
 
         this.ensurePosition();
 

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -66,13 +66,14 @@ class StreamMonitor {
     }
 
     reset() {
-        this.element.innerHTML = `
-            <section>
-                <div class="grid">
-                    <span style="grid-column: 1 / 4;">Loading stream data.</span>
-                </div>
-            </section>
-        `
+        // this.element.innerHTML = `
+        //     <section>
+        //         <div class="grid">
+        //             <span style="grid-column: 1 / 4;">Loading stream data.</span>
+        //         </div>
+        //     </section>
+        // `
+        this.updateValues(null)
 
         this._menuElement.reset()
     }
@@ -94,12 +95,35 @@ class StreamMonitor {
         }
     }
 
+    showMode(mode) {
+        switch (mode) {
+            case this._MODE.standard:
+                this._switchToStandard()
+                break
+            case this._MODE.compact:
+                this._switchToCompact()
+                break
+            case this._MODE.menu:
+                this._switchToMenu()
+                break
+            case this._MODE.hidden:
+                this._switchToHidden()
+                break
+        }
+    }
+
     get currentMode() {
         return this._currentMode;
     }
 
     // every second or so
     updateValues(data) {
+        this._currentData = data
+
+        if (data == null) {
+            return
+        }
+
         this.ensurePosition();
 
         data.codec = data.codec
@@ -129,8 +153,6 @@ class StreamMonitor {
             default:
                 break
         }
-
-        this._currentData = data
     }
 
     // Reposition if outside of visible area
@@ -164,7 +186,7 @@ class StreamMonitor {
 
     _switchToStandard() {
         this.ensurePosition();
-        this._showStandard(this._currentData)
+        this._showStandard()
         this._currentMode = this._MODE.standard
     }
 
@@ -186,10 +208,10 @@ class StreamMonitor {
         this._currentMode = this._MODE.hidden
     }
 
-    _showStandard(data) {
+    _showStandard() {
         this.ensurePosition();
 
-        this.element.innerHTML = this._createFull(data)
+        this.element.innerHTML = this._createFull(this._currentData)
         this.element.style.display = "block"
     }
 
@@ -201,9 +223,20 @@ class StreamMonitor {
     }
 
     _showMenu(data) {
+        if (data == null) {
+            this._menuElement.reset()
+        } else {
+            this._menuElement.updateContent(
+                data.codec,
+                data.resolution,
+                data.latency + " ms",
+                data.fps,
+                data.framedrop,
+                data.decode + " ms"
+            )
+        }
+
         this._menuElement.show()
-        // this.element.innerHTML = this._createSimple(data)
-        // this.element.style.display = "block"
     }
 
     _createFull(data) {

--- a/extension/monitor.js
+++ b/extension/monitor.js
@@ -34,7 +34,6 @@ class StreamMonitor {
     /**
      * @param {SettingsService} settingsService - used for persisting monitor-related settings
      * @param {translation[]} translations
-     * @param {string} initialMode
      * @param {string} initialPosition - position on screen where the monitor should be shown
      * @param {boolean} autoStartEnabled - if monitor should be automatically shown on startup
      */
@@ -53,9 +52,9 @@ class StreamMonitor {
         this.reset(autoStartEnabled)
 
         const initialMode = this._settingsService.getMonitorMode();
-        const isLegacy = Number.isInteger(initialMode)
+        const isLegacyMode = Number.isInteger(initialMode)
 
-        if (isLegacy) {
+        if (isLegacyMode && autoStartEnabled) {
             const legacyMode = this._modeFromSettingsNumber(initialMode)
             this._currentMode = legacyMode
 

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -38,4 +38,18 @@ class SettingsService {
         settings.monitorMode = mode
         this.saveSettings(settings)
     }
+
+    getMonitorAutoStart() {
+        const settings = this.getSettings()
+        return settings.monitorAutostart
+    }
+
+    /**
+     * @param {string} mode
+     */
+    saveMonitorAutoStart(mode) {
+        const settings = this.getSettings()
+        settings.monitorAutostart = mode
+        this.saveSettings(settings)
+    }
 }

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -9,10 +9,57 @@
  * required changes can be made in this file.
  */
 class SettingsService {
-    _storageKey
+    _DEFAULTS = {
+        version: '0.0.0',
+        avatar: '',
+
+        monitorMode: "Hidden",
+        monitorAutostart: "Hidden",
+        monitorPosition: '1rem|1rem', // top + "|" + left
+
+        clockMode: 0,
+        clockOption: 0,
+        codec: 0,
+        resolution: 0,
+        gridSize: 0,
+        desktopWidth: screen.width,
+        desktopHeight: screen.height,
+        filter: 0,
+        hideMessagePreview: 0,
+        hideQuickReply: 0,
+        hideInlinePreview: 0,
+        hideOfflineUsers: 0,
+        hideInvisibleUsers: 0,
+        hideLabels: 0,
+        dimOverlay: 0,
+        hideUserMedia: 0,
+        hideCategories: 0,
+        splitStore: 0,
+        hideFamilySharing: 0,
+        enableShortcuts: 0,
+        enableStadiaDatabase: 1,
+        enableStadiaHunters: 0,
+        updateNotifications: 0,
+        streamMode: 0,
+        wishlist: "",
+        gameFilter: "",
+        favoriteList: "",
+        postprocess: {}
+    }
+
+    _storageKey;
+    _username;
 
     constructor(username) {
+        this._username = username
         this._storageKey = "enhanced_" + username
+    }
+
+    getDefaultSettings() {
+        const settings = this._DEFAULTS
+        settings.user = this._username
+
+        return settings
     }
 
     getSettings() {
@@ -25,13 +72,16 @@ class SettingsService {
         localStorage.setItem(this._storageKey, json)
     }
 
+    /**
+     * @returns {("Standard"|"Compact"|"Menu"|"Hidden")} - Monitor mode
+     */
     getMonitorMode() {
         const settings = this.getSettings()
         return settings.monitorMode
     }
 
     /**
-     * @param {string} mode
+     * @param {("Standard"|"Compact"|"Menu"|"Hidden")} mode
      */
     saveMonitorMode(mode) {
         const settings = this.getSettings()
@@ -39,13 +89,30 @@ class SettingsService {
         this.saveSettings(settings)
     }
 
+    /**
+     * Get the streaming monitor mode that should be be automatically applied on game start.
+     *
+     * @returns {("Standard"|"Compact"|"Menu"|"Hidden")} - Monitor mode
+     */
     getMonitorAutoStart() {
         const settings = this.getSettings()
-        return settings.monitorAutostart
+        const monitorAutoStart = settings.monitorAutostart
+
+        // Legacy support. Possible legacy values were 0 (manual) and 1 (autostart). This will only happen on first
+        // start of the new version.
+        if (monitorAutoStart === 0) {
+            return "Hidden"
+        } else if (monitorAutoStart === 1) {
+            return "Standard"
+        }
+
+        return monitorAutoStart
     }
 
     /**
-     * @param {string} mode
+     * Save the streaming monitor mode that should be be automatically applied on game start.
+     *
+     * @param {("Standard"|"Compact"|"Menu"|"Hidden")} mode - Monitor mode
      */
     saveMonitorAutoStart(mode) {
         const settings = this.getSettings()

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -1,0 +1,41 @@
+/**
+ * Handles the retrieval and persistence of user information to local storage.
+ *
+ * Persisting and retrieval of user settings via localStorage is done in many different parts of the content scripts.
+ * The primary purpose of this class is to store the associated methods in a single place and make them discoverable for
+ * all content scripts. By adding methods for retrieving or persisting single setting values, we encapsulate the
+ * specifics of the storage mechanism and prevent corrupting the settings json by accident. In addition, if the
+ * persistence mechanism changes in the future, for example by using chrome storage instead of local storage, all
+ * required changes can be made in this file.
+ */
+class SettingsService {
+    _storageKey
+
+    constructor(username) {
+        this._storageKey = "enhanced_" + username
+    }
+
+    getSettings() {
+        const json = localStorage.getItem(this._storageKey);
+        return JSON.parse(json)
+    }
+
+    saveSettings(settings) {
+        let json = JSON.stringify(settings);
+        localStorage.setItem(this._storageKey, json)
+    }
+
+    getMonitorMode() {
+        const settings = this.getSettings()
+        return settings.monitorMode
+    }
+
+    /**
+     * @param {string} mode
+     */
+    saveMonitorMode(mode) {
+        const settings = this.getSettings()
+        settings.monitorMode = mode
+        this.saveSettings(settings)
+    }
+}


### PR DESCRIPTION
# Proof of concept: StreamMonitor mode-switching 
### Motivation
I wanted to implement a new mode for the streaming monitor that shows the values of the last minute in a chart to make it easier to see spikes in latency/decoding time. While trying to figure out how to switch to that mode, I realized that we should probably improve the selection of the currently available modes first, before introducing yet another one.

### What
A more intuitive way of switching between modes, by using the active-color and a description equivalent to how other StadiaEnhanced-options work (e.g. selecting codec). Instead of toggling the monitor on/off and then clicking or double-clicking to switch between modes, you can now simply cycle through all the available modes.

### Benefits
- quickly know if the streaming monitor is on/off, by getting feedback from the icon via color and description (in compact-mode it was sometimes hard to see if the monitor is enabled or not when in front of a dark background)
- easier discovery of available modes because you are forced to cycle through them (I personally didn't even know there was a compact- and standalone-mode until I saw the code)
- more intuitive way if switching modes (double-clicking is not self-explanatory, and many users probably don't know that this is possible unless they read the release-notes)

### Downsides
- if you enabled the monitor by mistake and you simply want to turn it off, you still have to cycle through all modes until it turns off

### Next Steps
What do you think? I wanted to get your feedback first, until I spend more time on this. There are some more things that should be done:
 - cleanup code
 - persist the currently selected monitor-mode into local-storage
 - make it work with the "stream-monitor-autostart" toggle


Screenshots of the different icon states:
![monitor_modes](https://user-images.githubusercontent.com/7899872/145794752-871faf55-b43e-44e6-be81-abafafd38923.png)

